### PR TITLE
Building on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/RustAudio/rust-portaudio.git"
 name = "portaudio"
 crate-type = ["rlib"]
 
-[build-dependencies]
+[target."cfg(not(windows))".build-dependencies]
 pkg-config = "0.3.6"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/RustAudio/rust-portaudio.git"
 name = "portaudio"
 crate-type = ["rlib"]
 
-[target."cfg(not(windows))".build-dependencies]
+[build-dependencies]
 pkg-config = "0.3.6"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -151,16 +151,24 @@ mod platform {
 #[cfg(windows)]
 mod platform {
     use std::path::Path;
+    use std::io::{self, Write};
+
+    const PORTAUDIO_DOWNLOAD_URL: &'static str = "http://www.portaudio.com";
+
+    fn print_lib_url() {
+        let msg = format!("Don't know how to build portaudio on Windows yet. Sources and build instructions available at: {}", PORTAUDIO_DOWNLOAD_URL);
+        io::stderr().write(msg.as_bytes()).unwrap();
+    }
 
     pub fn download() {
-        println!("Don't know how to build portaudio on Windows yet!");
+        print_lib_url();
     }
 
     pub fn build(_: &Path) {
-        println!("Don't know how to build portaudio on Windows yet!");
+        print_lib_url();
     }
 
     pub fn print_libs(_: &Path) {
-        println!("Don't know how to build portaudio on Windows yet!");
+        print_lib_url();
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -153,14 +153,14 @@ mod platform {
     use std::path::Path;
 
     pub fn download() {
-        panic!("Don't know how to build portaudio on Windows yet!");
+        println!("Don't know how to build portaudio on Windows yet!");
     }
 
     pub fn build(_: &Path) {
-        panic!("Don't know how to build portaudio on Windows yet!");
+        println!("Don't know how to build portaudio on Windows yet!");
     }
 
     pub fn print_libs(_: &Path) {
-        panic!("Don't know how to build portaudio on Windows yet!");
+        println!("Don't know how to build portaudio on Windows yet!");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#[cfg(not(windows))]
 extern crate pkg_config;
 
 use std::path::Path;
@@ -28,7 +27,6 @@ use std::env;
 #[cfg(all(unix, not(target_os = "linux")))]
 use unix_platform as platform;
 
-#[cfg(not(windows))]
 fn main() {
     if env::var("PORTAUDIO_ONLY_STATIC").is_err() {
         // If pkg-config finds a library on the system, we are done
@@ -37,11 +35,6 @@ fn main() {
         }
     }
 
-    build();
-}
-
-#[cfg(windows)]
-fn main() {
     build();
 }
 

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#[cfg(not(windows))]
 extern crate pkg_config;
 
 use std::path::Path;
@@ -27,6 +28,7 @@ use std::env;
 #[cfg(all(unix, not(target_os = "linux")))]
 use unix_platform as platform;
 
+#[cfg(not(windows))]
 fn main() {
     if env::var("PORTAUDIO_ONLY_STATIC").is_err() {
         // If pkg-config finds a library on the system, we are done
@@ -35,6 +37,11 @@ fn main() {
         }
     }
 
+    build();
+}
+
+#[cfg(windows)]
+fn main() {
     build();
 }
 


### PR DESCRIPTION
I've made the following changes to make rust-portaudio usable on Windows:

* `println!`s rather than `panic!`s in `build`
* no dependency on `pkg-config` on Windows
* `main` on Windows just invokes `build`

It's still doesn't build portaudio automatically, but after building it manually with Visual Studio as outlined [here](http://portaudio.com/docs/v19-doxydocs/compile_windows.html), and putting `portaudio.lib` and `portaudio_x64.dll` in the directory of a test project depending on rust-portaudio, where I copied the examples, I was able to run them. I haven't tested the MinGW toolchain (neither for building portaudio, nor the GNU ABI release of rustc) or 32 bit builds. There is a portaudio package available through MSYS's pacman, though.

I hope I didn't break anything in the Linux/Mac build; sorry if I did, I'm only using Rust for a couple of days now.