### PR TITLE
Correct visibility of Reader and Writer traits

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -66,7 +66,7 @@ pub trait Flow {
 }
 
 /// **Streams** that can be read by the user.
-trait Reader: Flow {
+pub trait Reader: Flow {
     /// The sample format for the readable buffer.
     type Sample;
     /// Borrow the readable **Buffer**.
@@ -76,7 +76,7 @@ trait Reader: Flow {
 }
 
 /// **Streams** that can be written to by the user for output to some DAC.
-trait Writer: Flow {
+pub trait Writer: Flow {
     /// The sample format for the writable buffer.
     type Sample;
     /// Mutably borrow the the writable **Buffer**.


### PR DESCRIPTION
```
$ cargo build
   Compiling portaudio v0.6.3
src/stream.rs:1169:21: 1169:27 warning: private trait in public interface (error E0445), #[warn(private_in_public)] on by default
src/stream.rs:1169     where F: Flow + Reader,
                                       ^~~~~~
src/stream.rs:1169:21: 1169:27 warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
src/stream.rs:1169:21: 1169:27 note: for more information, see the explanation for E0446 (`--explain E0446`)
src/stream.rs:1224:21: 1224:27 warning: private trait in public interface (error E0445), #[warn(private_in_public)] on by default
src/stream.rs:1224     where F: Flow + Writer,
                                       ^~~~~~
src/stream.rs:1224:21: 1224:27 warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
src/stream.rs:1224:21: 1224:27 note: for more information, see the explanation for E0446 (`--explain E0446`)
```
Private trait `Reader` and `Writer` were being used in a public interface `Stream`.

This fixes `E0446` in rustc 1.7.0.