### PR TITLE
Add `links = "portaudio"` to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 build = "build.rs"
 homepage = "https://github.com/RustAudio/rust-portaudio"
 repository = "https://github.com/RustAudio/rust-portaudio.git"
+links = "portaudio"
 
 [lib]
 name = "portaudio"


### PR DESCRIPTION
As described in http://doc.crates.io/build-script.html#the-links-manifest-key
This allows to overwrite search paths and linked libraries.