### PR TITLE
Replace Stream lifetime with `std::sync::Arc<Life>`

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -339,6 +339,10 @@ pub struct Duplex<I, O> {
 }
 
 
+unsafe impl Send for NonBlocking {}
+unsafe impl<M, F> Send for Stream<M, F> where M: Send, F: Send {}
+
+
 impl<S> Parameters<S> {
 
     /// Construct a new **Parameters**.


### PR DESCRIPTION
This should help to avoid some hacks that were involved when requiring `Stream` to be `'static` while retaining safety.

Closes #120.