### PR TITLE
Fix redirection from docs root

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<meta http-equiv="refresh" content="0; URL=http://jeremyletang.github.io/rust-portaudio/doc/portaudio/index.html">
+		<meta http-equiv="refresh" content="0; URL=http://rustaudio.github.io/rust-portaudio/doc/portaudio/index.html">
 	</head>
 	<body>
 	</body>


### PR DESCRIPTION
http://rustaudio.github.io/rust-portaudio/ currently redirects to 404.