### PR TITLE
[Do not merge] Partial work on #137. Only struct PaHostApiTypeId ported for now.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -60,22 +60,26 @@ pub const PRIMING_OUTPUT   : StreamCallbackFlags = 0x00000010;
 
 
 /// Unchanging unique identifiers for each supported host API
-pub type HostApiTypeId = i32;
-pub const PA_IN_DEVELOPMENT: HostApiTypeId = 0;
-pub const PA_DIRECT_SOUND: HostApiTypeId = 1;
-pub const PA_MME: HostApiTypeId = 2;
-pub const PA_ASIO: HostApiTypeId = 3;
-pub const PA_SOUND_MANAGER: HostApiTypeId = 4;
-pub const PA_CORE_AUDIO: HostApiTypeId = 5;
-pub const PA_OSS: HostApiTypeId = 7;
-pub const PA_ALSA: HostApiTypeId = 8;
-pub const PA_AL: HostApiTypeId = 9;
-pub const PA_BE_OS: HostApiTypeId = 10;
-pub const PA_WDMKS: HostApiTypeId = 11;
-pub const PA_JACK: HostApiTypeId = 12;
-pub const PA_WASAPI: HostApiTypeId = 13;
-pub const PA_AUDIO_SCIENCE_HPI: HostApiTypeId = 14;
-
+pub type PaHostApiIndex = ::std::os::raw::c_int;
+#[derive(Copy, Clone)]
+#[repr(u32)]
+#[derive(Debug)]
+pub enum PaHostApiTypeId {
+    paInDevelopment = 0,
+    paDirectSound = 1,
+    paMME = 2,
+    paASIO = 3,
+    paSoundManager = 4,
+    paCoreAudio = 5,
+    paOSS = 7,
+    paALSA = 8,
+    paAL = 9,
+    paBeOS = 10,
+    paWDMKS = 11,
+    paJACK = 12,
+    paWASAPI = 13,
+    paAudioScienceHPI = 14,
+}
 
 
 #[doc(hidden)]
@@ -126,7 +130,7 @@ pub struct C_PaHostErrorInfo {
 #[repr(C)]
 pub struct C_PaHostApiInfo {
     pub struct_version: i32,
-    pub host_type: i32,
+    pub host_type: PaHostApiTypeId,
     pub name: *const c_char,
     pub device_count: i32,
     pub default_input_device: i32,
@@ -154,7 +158,7 @@ extern "C" {
     pub fn Pa_GetHostApiCount() -> HostApiIndex;
     pub fn Pa_GetDefaultHostApi() -> HostApiIndex;
     pub fn Pa_GetHostApiInfo(hostApi : HostApiIndex) -> *const C_PaHostApiInfo;
-    pub fn Pa_HostApiTypeIdToHostApiIndex(type_id : HostApiTypeId) -> HostApiIndex;
+    pub fn Pa_HostApiTypeIdToHostApiIndex(type_id : PaHostApiTypeId) -> HostApiIndex;
     pub fn Pa_HostApiDeviceIndexToDeviceIndex(hostApi : HostApiIndex, hostApiDeviceIndex : i32) -> DeviceIndex;
     pub fn Pa_GetLastHostErrorInfo() -> *const C_PaHostErrorInfo;
     pub fn Pa_GetDeviceCount() -> DeviceIndex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,11 +337,11 @@ impl PortAudio {
     /// an error is encountered.
     ///
     /// TODO: Determine exactly what errors might occur (PA docs aren't clear on this).
-    pub fn host_api_type_id_to_host_api_index(&self, type_id: HostApiTypeId)
+    pub fn host_api_type_id_to_host_api_index(&self, type_id: ffi::PaHostApiTypeId)
         -> Result<HostApiIndex, Error>
     {
         unsafe {
-            result_from_host_api_index(ffi::Pa_HostApiTypeIdToHostApiIndex(type_id as i32))
+            result_from_host_api_index(ffi::Pa_HostApiTypeIdToHostApiIndex(type_id))
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -229,21 +229,22 @@ pub mod sample_format_flags {
 
     impl ::std::fmt::Display for SampleFormatFlags {
         fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-            write!(f, "{:?}", match self.bits() {
-                ffi::PA_FLOAT_32 => "FLOAT_32",
-                ffi::PA_INT_32 => "INT_32",
-                //ffi::PA_INT_24 => "INT_24",
-                ffi::PA_INT_16 => "INT_16",
-                ffi::PA_INT_8 => "INT_8",
-                ffi::PA_UINT_8 => "UINT_8",
-                ffi::PA_CUSTOM_FORMAT => "CUSTOM_FORMAT",
-                ffi::PA_NON_INTERLEAVED => "NON_INTERLEAVED",
-                _   => "<Unknown SampleFormatFlags>",
-            })
+            write!(f,
+                   "{:?}",
+                   match self.bits() {
+                       ffi::PA_FLOAT_32 => "FLOAT_32",
+                       ffi::PA_INT_32 => "INT_32",
+                       // ffi::PA_INT_24 => "INT_24",
+                       ffi::PA_INT_16 => "INT_16",
+                       ffi::PA_INT_8 => "INT_8",
+                       ffi::PA_UINT_8 => "UINT_8",
+                       ffi::PA_CUSTOM_FORMAT => "CUSTOM_FORMAT",
+                       ffi::PA_NON_INTERLEAVED => "NON_INTERLEAVED",
+                       _ => "<Unknown SampleFormatFlags>",
+                   })
         }
     }
 }
-
 
 
 /// Unchanging unique identifiers for each supported host API
@@ -251,58 +252,82 @@ pub mod sample_format_flags {
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum HostApiTypeId {
     /// In development host
-    InDevelopment =   ffi::PA_IN_DEVELOPMENT,
+    InDevelopment = ffi::PaHostApiTypeId::paInDevelopment as i32,
     /// Direct sound
-    DirectSound =     ffi::PA_DIRECT_SOUND,
+    DirectSound = ffi::PaHostApiTypeId::paDirectSound as i32,
     /// MMe API
-    MME =             ffi::PA_MME,
+    MME = ffi::PaHostApiTypeId::paMME as i32,
     /// ASIO API
-    ASIO =            ffi::PA_ASIO,
+    ASIO = ffi::PaHostApiTypeId::paASIO as i32,
     /// Sound manager API
-    SoundManager =    ffi::PA_SOUND_MANAGER,
+    SoundManager = ffi::PaHostApiTypeId::paSoundManager as i32,
     /// Core Audio API
-    CoreAudio =       ffi::PA_CORE_AUDIO,
+    CoreAudio = ffi::PaHostApiTypeId::paCoreAudio as i32,
     /// OSS API
-    OSS =             ffi::PA_OSS,
+    OSS = ffi::PaHostApiTypeId::paOSS as i32,
     /// Alsa API
-    ALSA =            ffi::PA_ALSA,
+    ALSA = ffi::PaHostApiTypeId::paALSA as i32,
     /// AL API
-    AL =              ffi::PA_AL,
+    AL = ffi::PaHostApiTypeId::paAL as i32,
     /// BeOS API
-    BeOS =            ffi::PA_BE_OS,
+    BeOS = ffi::PaHostApiTypeId::paBeOS as i32,
     /// WDMKS
-    WDMKS =           ffi::PA_WDMKS,
+    WDMKS = ffi::PaHostApiTypeId::paWDMKS as i32,
     /// Jack API
-    JACK =            ffi::PA_JACK,
+    JACK = ffi::PaHostApiTypeId::paJACK as i32,
     /// WASAPI
-    WASAPI =          ffi::PA_WASAPI,
+    WASAPI = ffi::PaHostApiTypeId::paWASAPI as i32,
     /// Audio Science HPI
-    AudioScienceHPI = ffi::PA_AUDIO_SCIENCE_HPI
+    AudioScienceHPI = ffi::PaHostApiTypeId::paAudioScienceHPI as i32,
 }
+
 
 impl HostApiTypeId {
     /// Convert the given ffi::HostApiTypeId to a HostApiTypeId.
-    pub fn from_c_id(c_id: ffi::HostApiTypeId) -> Option<Self> {
+    pub fn from_c_id(c_id: ffi::PaHostApiTypeId) -> Option<Self> {
         use self::HostApiTypeId::*;
+
         Some(match c_id {
-            ffi::PA_IN_DEVELOPMENT => InDevelopment,
-            ffi::PA_DIRECT_SOUND => DirectSound,
-            ffi::PA_MME => MME,
-            ffi::PA_ASIO => ASIO,
-            ffi::PA_SOUND_MANAGER => SoundManager,
-            ffi::PA_CORE_AUDIO => CoreAudio,
-            ffi::PA_OSS => OSS,
-            ffi::PA_ALSA => ALSA,
-            ffi::PA_AL => AL,
-            ffi::PA_BE_OS => BeOS,
-            ffi::PA_WDMKS => WDMKS,
-            ffi::PA_JACK => JACK,
-            ffi::PA_WASAPI => WASAPI,
-            ffi::PA_AUDIO_SCIENCE_HPI => AudioScienceHPI,
-            _ => return None,
+            ffi::PaHostApiTypeId::paInDevelopment => InDevelopment,
+            ffi::PaHostApiTypeId::paDirectSound => DirectSound,
+            ffi::PaHostApiTypeId::paMME => MME,
+            ffi::PaHostApiTypeId::paASIO => ASIO,
+            ffi::PaHostApiTypeId::paSoundManager => SoundManager,
+            ffi::PaHostApiTypeId::paCoreAudio => CoreAudio,
+            ffi::PaHostApiTypeId::paOSS => OSS,
+            ffi::PaHostApiTypeId::paALSA => ALSA,
+            ffi::PaHostApiTypeId::paAL => AL,
+            ffi::PaHostApiTypeId::paBeOS => BeOS,
+            ffi::PaHostApiTypeId::paWDMKS => WDMKS,
+            ffi::PaHostApiTypeId::paJACK => JACK,
+            ffi::PaHostApiTypeId::paWASAPI => WASAPI,
+            ffi::PaHostApiTypeId::paAudioScienceHPI => AudioScienceHPI,
         })
     }
+    
+    /// Convert from HostApiTypeId to a ffi::HostApiTypeId
+    pub fn to_ffi_id(t_id : HostApiTypeId) -> ffi::PaHostApiTypeId {
+        use self::HostApiTypeId::*;
+
+        match t_id {
+            InDevelopment => ffi::PaHostApiTypeId::paInDevelopment,
+            DirectSound => ffi::PaHostApiTypeId::paDirectSound,
+            MME => ffi::PaHostApiTypeId::paMME,
+            ASIO => ffi::PaHostApiTypeId::paASIO,
+            SoundManager => ffi::PaHostApiTypeId::paSoundManager,
+            CoreAudio => ffi::PaHostApiTypeId::paCoreAudio,
+            OSS => ffi::PaHostApiTypeId::paOSS,
+            ALSA => ffi::PaHostApiTypeId::paALSA,
+            AL => ffi::PaHostApiTypeId::paAL,
+            BeOS => ffi::PaHostApiTypeId::paBeOS,
+            WDMKS => ffi::PaHostApiTypeId::paWDMKS,
+            JACK => ffi::PaHostApiTypeId::paJACK,
+            WASAPI => ffi::PaHostApiTypeId::paWASAPI,
+            AudioScienceHPI => ffi::PaHostApiTypeId::paAudioScienceHPI,
+        }
+    }
 }
+
 
 /// A structure containing information about a particular host API.
 #[derive(Clone, Debug, PartialEq)]
@@ -371,9 +396,11 @@ impl<'a> From<HostApiInfo<'a>> for ffi::C_PaHostApiInfo {
             Some(i) => i.into(),
             None    => ffi::PA_NO_DEVICE,
         };
+
+        let host_type: ffi::PaHostApiTypeId = HostApiTypeId::to_ffi_id(info.host_type);
         ffi::C_PaHostApiInfo {
             struct_version: info.struct_version as i32,
-            host_type: info.host_type as i32,
+            host_type: host_type,
             name: ffi::str_to_c_str(info.name),
             device_count: info.device_count as i32,
             default_input_device: default_input_device,


### PR DESCRIPTION
Did an initial run with bindgen + ported over a small section of the resulting ffi.rs. I.e. only the  (Pa)HostApiTypeId enum. Then I fixed breakage such that the `devices.rs`, `hosts.rs` and `sine.rs` examples seem to work.

The existing solution defines a bunch of consts in `ffi.rs` with a wrapping enum in `types.rs`. Running bindgen creates an enum right in `ffi.rs`, giving us two enums with basically the same members. 

Since bindgen does the enum stuff, I guess we might as well drop the enum in `types.rs` altogether? Haven't tried doing that to see what breaks yet.

Looking at the generated `.rs`, naming and types change a bit. See DeviceInfo struct below. So fixing this issue will break a lot of API. Don't know if RustAudio has a policy on that.

```
$ diff -y ffi-regen.rs src/ffi.rs
(... snip ...)
pub type PaTime = f64;                                        |
pub type PaSampleFormat = ::std::os::raw::c_ulong;            | #[derive(Clone, Copy, Debug)]
#[repr(C)]                                                      #[repr(C)]
#[derive(Copy, Clone)]                                        | pub struct C_PaDeviceInfo {
#[derive(Debug)]                                              |     pub struct_version: i32,
pub struct PaDeviceInfo {                                     |     pub name: *const c_char,
    pub structVersion: ::std::os::raw::c_int,                 |     pub host_api: HostApiIndex,
    pub name: *const ::std::os::raw::c_char,                  |     pub max_input_channels: i32,
    pub hostApi: PaHostApiIndex,                              |     pub max_output_channels: i32,
    pub maxInputChannels: ::std::os::raw::c_int,              |     pub default_low_input_latency: Time,
    pub maxOutputChannels: ::std::os::raw::c_int,             |     pub default_low_output_latency: Time,
    pub defaultLowInputLatency: PaTime,                       |     pub default_high_input_latency: Time,
    pub defaultLowOutputLatency: PaTime,                      |     pub default_high_output_latency: Time,
    pub defaultHighInputLatency: PaTime,                      |     pub default_sample_rate: c_double
    pub defaultHighOutputLatency: PaTime,                     <
    pub defaultSampleRate: f64,                               <
}                                                             <
(... snip ...)
```