### PR TITLE
Implemented CMake-based builds on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ crate-type = ["rlib"]
 [build-dependencies]
 pkg-config = "0.3.6"
 
+[target.'cfg(windows)'.build-dependencies]
+cmake = "0.1"
+
 [dependencies]
 bitflags = "0.7"
 libc = "0.2.14"

--- a/download.cmake
+++ b/download.cmake
@@ -1,0 +1,6 @@
+set(url http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz)
+set(archive "$ENV{OUT_DIR}/portaudio.tgz")
+
+file(DOWNLOAD "${url}" "${archive}")
+execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xvf "${archive}"
+    WORKING_DIRECTORY "$ENV{OUT_DIR}")


### PR DESCRIPTION
The next step is to enable Windows builds in '.travis.yml' I think.