### PR TITLE
Build script improvements

### DIFF
--- a/rust-portaudio-sys/build.rs
+++ b/rust-portaudio-sys/build.rs
@@ -21,9 +21,10 @@
 
 extern crate pkg_config;
 
-use std::path::Path;
 use std::env;
 use std::fmt::Display;
+use std::path::Path;
+use std::process::Command;
 
 #[cfg(all(unix, not(target_os = "linux")))]
 use unix_platform as platform;
@@ -65,6 +66,14 @@ fn err_to_panic<T, E: Display>(result: Result<T, E>) -> T {
     }
 }
 
+fn run(command: &mut Command) {
+    let string = format!("{:?}", command);
+    let status = err_to_panic(command.status());
+    if !status.success() {
+        panic!("`{}` did not execute successfully", string);
+    }
+}
+
 #[allow(dead_code)]
 mod unix_platform {
     use std::process::Command;
@@ -72,42 +81,41 @@ mod unix_platform {
 
     use std::env;
 
-    use super::err_to_panic;
+    use super::{err_to_panic, run};
 
     pub const PORTAUDIO_URL: &'static str = "http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz";
     pub const PORTAUDIO_TAR: &'static str = "pa_stable_v19_20140130.tgz";
     pub const PORTAUDIO_FOLDER: &'static str = "portaudio";
 
     pub fn download() {
-        err_to_panic(Command::new("curl").arg(PORTAUDIO_URL).arg("-O").output());
+        run(Command::new("curl").arg(PORTAUDIO_URL).arg("-O"));
     }
 
     pub fn build(out_dir: &Path) {
         // untar portaudio sources
-        err_to_panic(Command::new("tar").arg("xvf").arg(PORTAUDIO_TAR).output());
+        run(Command::new("tar").arg("xvf").arg(PORTAUDIO_TAR));
 
         // change dir to the portaudio folder
         err_to_panic(env::set_current_dir(PORTAUDIO_FOLDER));
 
         // run portaudio autoconf
-        err_to_panic(Command::new("./configure")
+        run(Command::new("./configure")
             .args(&["--disable-shared", "--enable-static"]) // Only build static lib
             .args(&["--prefix", out_dir.to_str().unwrap()]) // Install on the outdir
-            .arg("--with-pic") // Build position-independent code (required by Rust)
-            .output());
+            .arg("--with-pic")); // Build position-independent code (required by Rust)
 
         // then make
-        err_to_panic(Command::new("make").output());
+        run(&mut Command::new("make"));
 
         // "install" on the outdir
-        err_to_panic(Command::new("make").arg("install").output());
+        run(Command::new("make").arg("install"));
 
         // return to rust-portaudio root
         err_to_panic(env::set_current_dir(".."));
 
         // cleaning portaudio sources
-        err_to_panic(Command::new("rm").arg("-rf")
-            .args(&[PORTAUDIO_TAR, PORTAUDIO_FOLDER]).output());
+        run(Command::new("rm").arg("-rf")
+            .args(&[PORTAUDIO_TAR, PORTAUDIO_FOLDER]));
     }
 
     pub fn print_libs(out_dir: &Path) {
@@ -123,10 +131,10 @@ mod platform {
     use super::unix_platform;
     use std::path::Path;
 
-    use super::err_to_panic;
+    use super::{run, err_to_panic};
 
     pub fn download() {
-        err_to_panic(Command::new("wget").arg(unix_platform::PORTAUDIO_URL).output());
+        run(Command::new("wget").arg(unix_platform::PORTAUDIO_URL));
     }
 
     pub fn build(out_dir: &Path) {

--- a/rust-portaudio-sys/build.rs
+++ b/rust-portaudio-sys/build.rs
@@ -29,6 +29,9 @@ use std::fmt::Display;
 use unix_platform as platform;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    println!("cargo:rerun-if-env-changed=PORTAUDIO_ONLY_STATIC");
     if env::var("PORTAUDIO_ONLY_STATIC").is_err() {
         // If pkg-config finds a library on the system, we are done
         if pkg_config::Config::new().atleast_version("19").find("portaudio-2.0").is_ok() {


### PR DESCRIPTION
- Don't capture the output from the build script; now it will be shown if the build fails or with `cargo build -vv`
- Rerun the build script if the environment or the build script changes.