### PR TITLE
Added "NoDevice" to the list of Portaudio errors

### DIFF
--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -16,7 +16,12 @@ const INTERLEAVED: bool = true;
 
 
 fn main() {
-    run().unwrap()
+    match run() {
+        Ok(_) => {},
+        e => {
+            eprintln!("Example failed with the following: {:?}", e);
+        }
+    }
 }
 
 fn run() -> Result<(), pa::Error> {

--- a/examples/devices.rs
+++ b/examples/devices.rs
@@ -13,7 +13,12 @@ const STANDARD_SAMPLE_RATES: [f64; 13] = [
 
 
 fn main() {
-    run().unwrap()
+    match run() {
+        Ok(_) => {},
+        e => {
+            eprintln!("Example failed with the following: {:?}", e);
+        }
+    }
 }
 
 

--- a/examples/hosts.rs
+++ b/examples/hosts.rs
@@ -4,11 +4,22 @@
 extern crate portaudio as pa;
 
 fn main() {
-    let pa = pa::PortAudio::new().unwrap();
+    match run() {
+        Ok(_) => {},
+        e => {
+            eprintln!("Example failed with the following: {:?}", e);
+        }
+    }
+}
+
+fn run() -> Result<(), pa::Error> {
+    let pa = try!(pa::PortAudio::new());
 
     println!("Default Host API: {:?}", pa.default_host_api());
     println!("All Host APIs:");
     for host in pa.host_apis() {
         println!("{:#?}", host);
     }
+
+    Ok(())
 }

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -15,7 +15,12 @@ const INTERLEAVED: bool = true;
 
 
 fn main() {
-    run().unwrap()
+    match run() {
+        Ok(_) => {},
+        e => {
+            eprintln!("Example failed with the following: {:?}", e);
+        }
+    }
 }
 
 fn run() -> Result<(), pa::Error> {

--- a/examples/saw.rs
+++ b/examples/saw.rs
@@ -13,7 +13,12 @@ const SAMPLE_RATE: f64 = 44_100.0;
 const FRAMES_PER_BUFFER: u32 = 64;
 
 fn main() {
-    run().unwrap()
+    match run() {
+        Ok(_) => {},
+        e => {
+            eprintln!("Example failed with the following: {:?}", e);
+        }
+    }
 }
 
 

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -16,7 +16,12 @@ const TABLE_SIZE: usize = 200;
 
 
 fn main() {
-    run().unwrap()
+    match run() {
+        Ok(_) => {},
+        e => {
+            eprintln!("Example failed with the following: {:?}", e);
+        }
+    }
 }
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     /// No Error
     NoError =
         ffi::PaErrorCode_paNoError,
+    /// No audio devices
+    NoDevice =
+        ffi::PA_NO_DEVICE,
     /// Portaudio not initialized
     NotInitialized =
         ffi::PaErrorCode_paNotInitialized,
@@ -113,6 +116,7 @@ impl ::std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::NoError => "No Error",
+            Error::NoDevice  => "No Device",
             Error::NotInitialized => "PortAudio not initialized",
             Error::UnanticipatedHostError => "Unanticipated error from the host",
             Error::InvalidChannelCount => "Invalid number of channels",


### PR DESCRIPTION
This is the error that portaudio returns if you ask for the default
device, but the system doesn't have a default device.

Before this change, Portaudio returning NoDevice would result in a
panic. Now, it will result in the new error being returned.

I also updated the examples to avoid panicking, and rather print the
error message and exit gracefully.

#142 