### PR TITLE
Update upstream dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/RustAudio/rust-portaudio"
 repository = "https://github.com/RustAudio/rust-portaudio.git"
 
 [dependencies]
-bitflags = "0.7"
-libc = "0.2.14"
-num = { version = "0.1.34", default-features = false }
+bitflags = "0.8.2"
+libc = "0.2.51"
+num = { version = "0.2.0", default-features = false }
 portaudio_sys = { path = "./rust-portaudio-sys", version = "0.1.0" }


### PR DESCRIPTION
Resolve #172 to minimize side effects from older versions of other libraries
Note that updating "bitflags" would require code changes so that was kept independent of this PR