### PR TITLE
mscv configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ On Mac OS X, you may need to install manually `portaudio` and `pkg-config` (usin
 
 You can build the tests and examples with `cargo test`, and the documentation with `cargo doc`.
 
+# Installation on windows-msvc
+
+On the windows-msvc, **rust-portaudio-sys** uses the Visual Studio solution file to build portaudio.
+So, the following programs must be put through the system `PATH`.
+
+- **Git**: getting the source code from repository
+- **devenv**: updating the solution file in the repository of portaudio
+- **MSBuild**: building PortAudio statically
+
+It is remark that cargo does not read the user-wise path, so you must add these programs to the system path.
+

--- a/rust-portaudio-sys/Cargo.toml
+++ b/rust-portaudio-sys/Cargo.toml
@@ -17,3 +17,4 @@ crate-type = ["rlib"]
 
 [build-dependencies]
 pkg-config = "0.3.6"
+force_remove = "0.1.1"


### PR DESCRIPTION
Installation portaudio on windows-msvc. Users must put Git, devenv, and msbuild through the system path.
As for msbuild and devenv, maybe there's a way to get rid of the path, but I didn't see it.
The standard Windows commands are used to get ASIOSDK and extract the zip, so no new tools are needed.