### PR TITLE
Remove no-longer relevant FIXME

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,8 +612,6 @@ pub fn version() -> i32 {
 }
 
 /// Retrieve a textual description of the current PortAudio build.
-///
-/// FIXME: This should return a `&'static str`, not a `String`.
 pub fn version_text() -> Result<&'static str, ::std::str::Utf8Error> {
     unsafe { ffi::c_str_to_str(ffi::Pa_GetVersionText()) }
 }


### PR DESCRIPTION
I think there was a change made previously that already changed the return type.