### PR TITLE
update portaudio

### DIFF
--- a/rust-portaudio-sys/build.rs
+++ b/rust-portaudio-sys/build.rs
@@ -83,8 +83,8 @@ mod unix_platform {
 
     use super::{err_to_panic, run};
 
-    pub const PORTAUDIO_URL: &'static str = "http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz";
-    pub const PORTAUDIO_TAR: &'static str = "pa_stable_v19_20140130.tgz";
+    pub const PORTAUDIO_URL: &'static str = "https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz";
+    pub const PORTAUDIO_TAR: &'static str = "pa_stable_v190700_20210406.tgz";
     pub const PORTAUDIO_FOLDER: &'static str = "portaudio";
 
     pub fn download() {


### PR DESCRIPTION
Hey, hope it's not too forward to lead with a PR. Figured it's a tiny change so might as well clarify that part up front.

I was hitting https://github.com/PortAudio/portaudio/issues/268 and noticed the portaudio people solved it somewhere in 2020, and made a release in 2021. I tried installing that version of portaudio, but need a static build. pgk_config has its own unsolved problem with static system libraries https://github.com/rust-lang/pkg-config-rs/issues/102.

Not sure of a couple things:
- how married is this wrapper to 2014 portaudio?
- am I missing some other way to get what I need?

I can confirm this changed solved my issue. Not sure about anything but dead obvious regressions, though.

All the best,
Dan